### PR TITLE
adjust cors.rb file to match heroku FE url

### DIFF
--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -7,7 +7,7 @@
 
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
-    origins ['http://localhost:3000', 'https://no-use-cryin-over-shared-milk.herokuapp.com/']
+    origins ['http://localhost:3000', 'https://no-use-cryin-over-shared-milk.herokuapp.com']
 
     resource '*',
       headers: :any,


### PR DESCRIPTION
Is this a fix or a feature?
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
 
Describe the feature - fix - refactor:

remove slash from FE URL in cors.rb for heroku, to hopefully solve cors issues

How was this tested?
- [ ] open index.html
- [ ] localhost
- [ ] terminal

Where should the reviewer start - test:



Additional comments:
